### PR TITLE
DRD-1887: strict mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.ossindex</groupId>
 	<artifactId>heuristic-version</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Utility classes that help parse and compare version strings</description>

--- a/pom.xml
+++ b/pom.xml
@@ -161,5 +161,11 @@
 			<artifactId>antlr4</artifactId>
 			<version>4.5</version>
 		</dependency>
+
+		<dependency>
+			<groupId>pl.pragmatists</groupId>
+			<artifactId>JUnitParams</artifactId>
+			<version>1.0.5</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.ossindex</groupId>
 	<artifactId>heuristic-version</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Utility classes that help parse and compare version strings</description>

--- a/src/main/java/net/ossindex/version/InvalidRangeException.java
+++ b/src/main/java/net/ossindex/version/InvalidRangeException.java
@@ -10,4 +10,8 @@ public class InvalidRangeException
   public InvalidRangeException(String msg) {
     super(msg);
   }
+
+  public InvalidRangeException(final String message, final InvalidRangeRuntimeException cause) {
+    super(message, cause);
+  }
 }

--- a/src/main/java/net/ossindex/version/InvalidRangeException.java
+++ b/src/main/java/net/ossindex/version/InvalidRangeException.java
@@ -1,0 +1,13 @@
+package net.ossindex.version;
+
+public class InvalidRangeException
+    extends Exception
+{
+  public InvalidRangeException(Throwable cause) {
+    super(cause);
+  }
+
+  public InvalidRangeException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/net/ossindex/version/InvalidRangeRuntimeException.java
+++ b/src/main/java/net/ossindex/version/InvalidRangeRuntimeException.java
@@ -1,0 +1,13 @@
+package net.ossindex.version;
+
+/**
+ * The parser is not happy with us injection a regular exception, so make this one a RuntimeException. We will
+ * catch and convert it later.
+ */
+public class InvalidRangeRuntimeException
+    extends RuntimeException
+{
+  public InvalidRangeRuntimeException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/net/ossindex/version/InvalidRangeRuntimeException.java
+++ b/src/main/java/net/ossindex/version/InvalidRangeRuntimeException.java
@@ -10,4 +10,8 @@ public class InvalidRangeRuntimeException
   public InvalidRangeRuntimeException(String msg) {
     super(msg);
   }
+
+  public InvalidRangeRuntimeException(final String message, final InvalidRangeException cause) {
+    super(message, cause);
+  }
 }

--- a/src/main/java/net/ossindex/version/InvalidRangeRuntimeException.java
+++ b/src/main/java/net/ossindex/version/InvalidRangeRuntimeException.java
@@ -1,7 +1,7 @@
 package net.ossindex.version;
 
 /**
- * The parser is not happy with us injection a regular exception, so make this one a RuntimeException. We will
+ * The parser is not happy with us injecting a regular exception, so make this one a RuntimeException. We will
  * catch and convert it later.
  */
 public class InvalidRangeRuntimeException

--- a/src/main/java/net/ossindex/version/VersionFactory.java
+++ b/src/main/java/net/ossindex/version/VersionFactory.java
@@ -61,7 +61,7 @@ public class VersionFactory
 
   private static VersionFactory instance;
 
-  private boolean strict = false;
+  private final boolean strict;
 
   /**
    * Private. Use "getVersionFactory" instead.

--- a/src/main/java/net/ossindex/version/VersionFactory.java
+++ b/src/main/java/net/ossindex/version/VersionFactory.java
@@ -57,6 +57,15 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
  */
 public class VersionFactory
 {
+  // These characters have special meaning for semantic ranges, so should not be in named versions
+  private static final Pattern SEMANTIC_RANGE_SPECIAL_CHARS = Pattern.compile("[><=|&]");
+
+  // Maven ranges star with ( or [, so we should not allow any version wih these characters to become named versions
+  private static final Pattern SET_RANGE_SPECIAL_CHARS = Pattern.compile("^[\\(\\[]");
+
+  // We just won't let these charactersm happen in a named version because that would be madness
+  private static final Pattern INVALID_VERSION_CHARS = Pattern.compile("[ \t\n\r]");
+
   private static VersionFactory strictInstance;
 
   private static VersionFactory instance;
@@ -190,15 +199,6 @@ public class VersionFactory
     IVersion version = new NamedVersion(vstring);
     return new VersionSet(version);
   }
-
-  // These characters have special meaning for semantic ranges, so should not be in named versions
-  private static final Pattern SEMANTIC_RANGE_SPECIAL_CHARS = Pattern.compile("[><=|&]");
-
-  // Maven ranges star with ( or [, so we should not allow any version wih these characters to become named versions
-  private static final Pattern SET_RANGE_SPECIAL_CHARS = Pattern.compile("^[\\(\\[]");
-
-  // We just won't let these charactersm happen in a named version because that would be madness
-  private static final Pattern INVALID_VERSION_CHARS = Pattern.compile("[ \t\n\r]");
 
   /**
    * People use all sorts of whack characters in version. We are just excluding

--- a/src/main/java/net/ossindex/version/VersionFactory.java
+++ b/src/main/java/net/ossindex/version/VersionFactory.java
@@ -170,12 +170,11 @@ public class VersionFactory
       System.err.println("ERROR: Could not parse: " + vstring);
     }
     catch (InvalidRangeRuntimeException e) {
-      if (strict) {
-        throw new InvalidRangeException(e.getMessage(), e);
-      }
-      System.err.println("ERROR: Could not parse: " + vstring);
+      // These are always critical. They indicate a fundamental problem with the version range.
+      throw new InvalidRangeException(e.getMessage(), e);
     }
     catch (Exception e) {
+      // Parse errors and wot not will come here
       if (strict) {
         throw new InvalidRangeException(e);
       }
@@ -207,8 +206,8 @@ public class VersionFactory
    */
   private boolean isValidNamedVersion(final String s) {
     if (SEMANTIC_RANGE_SPECIAL_CHARS.matcher(s).find()
-            || SET_RANGE_SPECIAL_CHARS.matcher(s).find()
-            || INVALID_VERSION_CHARS.matcher(s).find()
+        || SET_RANGE_SPECIAL_CHARS.matcher(s).find()
+        || INVALID_VERSION_CHARS.matcher(s).find()
         ) {
       return false;
     }

--- a/src/main/java/net/ossindex/version/VersionFactory.java
+++ b/src/main/java/net/ossindex/version/VersionFactory.java
@@ -167,15 +167,19 @@ public class VersionFactory
       if (strict) {
         throw new InvalidRangeException(e);
       }
-      System.err.println("Could not parse: " + vstring);
-      e.printStackTrace();
+      System.err.println("ERROR: Could not parse: " + vstring);
+    }
+    catch (InvalidRangeRuntimeException e) {
+      if (strict) {
+        throw new InvalidRangeException(e.getMessage(), e);
+      }
+      System.err.println("ERROR: Could not parse: " + vstring);
     }
     catch (Exception e) {
       if (strict) {
         throw new InvalidRangeException(e);
       }
-      System.err.println("Could not parse: " + vstring);
-      e.printStackTrace();
+      System.err.println("ERROR: Could not parse: " + vstring);
     }
 
     // Don't make a named version of a string we should have parsed.

--- a/src/main/java/net/ossindex/version/impl/AndRange.java
+++ b/src/main/java/net/ossindex/version/impl/AndRange.java
@@ -28,11 +28,13 @@ package net.ossindex.version.impl;
 
 import net.ossindex.version.IVersion;
 import net.ossindex.version.IVersionRange;
+import net.ossindex.version.InvalidRangeException;
+import net.ossindex.version.InvalidRangeRuntimeException;
 
-/** Two ranges anded together
+/**
+ * Two ranges anded together
  *
  * @author Ken Duck
- *
  */
 public class AndRange
     extends AbstractCommonRange
@@ -54,11 +56,11 @@ public class AndRange
   /**
    * And the ranges, ordering them in Vor's preferred order.
    */
-  public AndRange(IVersionRange range1, IVersionRange range2)
+  public AndRange(IVersionRange range1, IVersionRange range2) throws InvalidRangeRuntimeException
   {
     // The ranges should intersect
     if (!range1.intersects(range2)) {
-      throw new AssertionError(
+      throw new InvalidRangeRuntimeException(
           "Anded ranges do not intersect; this can never happen [" + range1 + " & " + range2 + "]");
     }
 

--- a/src/main/java/net/ossindex/version/impl/NamedVersion.java
+++ b/src/main/java/net/ossindex/version/impl/NamedVersion.java
@@ -26,22 +26,36 @@
  */
 package net.ossindex.version.impl;
 
-import net.ossindex.version.IVersion;
+import java.util.regex.Pattern;
 
-/** Simple version that is based on name comparisons. This should be used as
+import net.ossindex.version.IVersion;
+import net.ossindex.version.InvalidRangeException;
+
+/**
+ * Simple version that is based on name comparisons. This should be used as
  * a last resort.
  *
  * @author Ken Duck
- *
  */
 public class NamedVersion
     implements IVersion
 {
+  // These characters have special meaning for semantic ranges, so should not be in named versions
+  private static final Pattern SEMANTIC_RANGE_SPECIAL_CHARS = Pattern.compile("[><=|&]");
+
+  // Maven ranges star with ( or [, so we should not allow any version wih these characters to become named versions
+  private static final Pattern SET_RANGE_SPECIAL_CHARS = Pattern.compile("^[\\(\\[]");
+
+  // We just won't let these charactersm happen in a named version because that would be madness
+  private static final Pattern INVALID_VERSION_CHARS = Pattern.compile("[ \t\n\r]");
 
   private String name;
 
-  public NamedVersion(String name)
+  public NamedVersion(String name) throws InvalidRangeException
   {
+    if (!isValidNamedVersion(name)) {
+      throw new InvalidRangeException("Could not parse: " + name);
+    }
     this.name = name;
   }
 
@@ -131,5 +145,19 @@ public class NamedVersion
   public String toString()
   {
     return name;
+  }
+
+  /**
+   * People use all sorts of whack characters in version. We are just excluding
+   * the smallest set that we can.
+   */
+  private boolean isValidNamedVersion(final String s) {
+    if (SEMANTIC_RANGE_SPECIAL_CHARS.matcher(s).find()
+        || SET_RANGE_SPECIAL_CHARS.matcher(s).find()
+        || INVALID_VERSION_CHARS.matcher(s).find()
+        ) {
+      return false;
+    }
+    return true;
   }
 }

--- a/src/main/java/net/ossindex/version/impl/NamedVersion.java
+++ b/src/main/java/net/ossindex/version/impl/NamedVersion.java
@@ -43,10 +43,10 @@ public class NamedVersion
   // These characters have special meaning for semantic ranges, so should not be in named versions
   private static final Pattern SEMANTIC_RANGE_SPECIAL_CHARS = Pattern.compile("[><=|&]");
 
-  // Maven ranges star with ( or [, so we should not allow any version wih these characters to become named versions
+  // Maven ranges start with ( or [, so we should not allow any version wih these characters to become named versions
   private static final Pattern SET_RANGE_SPECIAL_CHARS = Pattern.compile("^[\\(\\[]");
 
-  // We just won't let these charactersm happen in a named version because that would be madness
+  // We just won't let these characters happen in a named version because that would be madness
   private static final Pattern INVALID_VERSION_CHARS = Pattern.compile("[ \t\n\r]");
 
   private String name;

--- a/src/main/java/net/ossindex/version/impl/VersionListener.java
+++ b/src/main/java/net/ossindex/version/impl/VersionListener.java
@@ -32,6 +32,8 @@ import java.util.regex.Pattern;
 
 import net.ossindex.version.IVersion;
 import net.ossindex.version.IVersionRange;
+import net.ossindex.version.InvalidRangeException;
+import net.ossindex.version.InvalidRangeRuntimeException;
 import net.ossindex.version.parser.VersionBaseListener;
 import net.ossindex.version.parser.VersionParser;
 
@@ -281,7 +283,7 @@ public class VersionListener
       stack.push(range);
     }
     else {
-      throw new AssertionError("Expected a semantic version, got a " + o.getClass().getSimpleName());
+      throw new InvalidRangeRuntimeException("Expected a semantic version, got a " + o.getClass().getSimpleName());
     }
   }
 

--- a/src/main/java/net/ossindex/version/impl/VersionListener.java
+++ b/src/main/java/net/ossindex/version/impl/VersionListener.java
@@ -52,16 +52,17 @@ public class VersionListener
 
   private static final Pattern startsWithDigitLetterOrHyphen = Pattern.compile("^[0-9a-zA-Z\\-]");
 
-  private boolean strict = false;
+  private final boolean strict;
 
   private Stack<Object> stack = new Stack<Object>();
 
   private IVersionRange range;
 
-  public VersionListener() {super();}
+  public VersionListener() {
+    this.strict = false;
+  }
 
   public VersionListener(final boolean strict) {
-    super();
     this.strict = strict;
   }
 

--- a/src/main/java/net/ossindex/version/impl/VersionListener.java
+++ b/src/main/java/net/ossindex/version/impl/VersionListener.java
@@ -147,7 +147,11 @@ public class VersionListener
     SemanticVersion version = null;
 
     int count = ctx.getChildCount();
-    String postfix = (String) stack.pop();
+    Object o = stack.pop();
+    if (!(o instanceof String)) {
+      throw new InvalidRangeRuntimeException("Expected string, got " + o.getClass().getSimpleName());
+    }
+    String postfix = (String) o;
     switch (count) {
       case 4: {
         //1.2.3alpha

--- a/src/main/java/net/ossindex/version/impl/VersionListener.java
+++ b/src/main/java/net/ossindex/version/impl/VersionListener.java
@@ -149,7 +149,7 @@ public class VersionListener
     int count = ctx.getChildCount();
     Object o = stack.pop();
     if (!(o instanceof String)) {
-      throw new InvalidRangeRuntimeException("Expected string, got " + o.getClass().getSimpleName());
+      throw new InvalidRangeRuntimeException("Expected string, got " + o.getClass().getSimpleName() + " (" + o + ")");
     }
     String postfix = (String) o;
     switch (count) {

--- a/src/main/java/net/ossindex/version/impl/VersionListener.java
+++ b/src/main/java/net/ossindex/version/impl/VersionListener.java
@@ -52,9 +52,18 @@ public class VersionListener
 
   private static final Pattern startsWithDigitLetterOrHyphen = Pattern.compile("^[0-9a-zA-Z\\-]");
 
+  private boolean strict = false;
+
   private Stack<Object> stack = new Stack<Object>();
 
   private IVersionRange range;
+
+  public VersionListener() {super();}
+
+  public VersionListener(final boolean strict) {
+    super();
+    this.strict = strict;
+  }
 
   public IVersionRange getRange()
   {
@@ -230,7 +239,13 @@ public class VersionListener
   @Override
   public void exitNamed_version(VersionParser.Named_versionContext ctx)
   {
-    IVersion version = new NamedVersion(ctx.getText());
+    IVersion version = null;
+    try {
+      version = new NamedVersion(ctx.getText());
+    }
+    catch (InvalidRangeException e) {
+      throw new InvalidRangeRuntimeException(e.getMessage(), e);
+    }
     stack.push(version);
   }
 
@@ -485,4 +500,13 @@ public class VersionListener
     }
   }
 
+  /**
+   * In strict mode we will want to disallow broken ranges
+   */
+  @Override
+  public void exitBroken_range(VersionParser.Broken_rangeContext ctx) {
+    if (strict) {
+      throw new InvalidRangeRuntimeException("Cannot create 'broken' range in strict mode");
+    }
+  }
 }

--- a/src/main/java/net/ossindex/version/impl/VersionRange.java
+++ b/src/main/java/net/ossindex/version/impl/VersionRange.java
@@ -28,14 +28,13 @@ package net.ossindex.version.impl;
 
 import java.util.Collection;
 
-import com.sun.javafx.binding.StringFormatter;
 import net.ossindex.version.IVersion;
 import net.ossindex.version.IVersionRange;
 
-/** A bounded version range is capped at both ends, for example 1.2.5 - 1.2.8
+/**
+ * A bounded version range is capped at both ends, for example 1.2.5 - 1.2.8
  *
  * @author Ken Duck
- *
  */
 public class VersionRange
     extends AbstractCommonRange
@@ -207,10 +206,11 @@ public class VersionRange
         mavenString = "(%s,)";
         break;
       default:
-       toString();
+        toString();
     }
     return String.format(mavenString, version);
   }
+
   /*
    * (non-Javadoc)
    * @see net.ossindex.version.IVersionRange#intersects(net.ossindex.version.IVersionRange)
@@ -225,10 +225,41 @@ public class VersionRange
     // If the other range is a simple range, then we can just check the extremities
     // to see if they overlap
     else if (yourRange instanceof VersionRange) {
-      if (yourRange.contains(version)) {
+      IVersion useMyVersion = null;
+      switch (operator) {
+        case ">":
+          useMyVersion = version.getNextVersion();
+          break;
+        case "<":
+          useMyVersion = version.getPrevVersion();
+          break;
+        default:
+          useMyVersion = version;
+          break;
+      }
+      if (yourRange.contains(useMyVersion)) {
         return true;
       }
-      if (this.contains(((VersionRange) yourRange).version)) {
+
+      IVersion useYourVersion = null;
+      switch (((VersionRange) yourRange).operator) {
+        case ">":
+          useYourVersion = ((VersionRange) yourRange).version.getNextVersion();
+          break;
+        case "<":
+          useYourVersion = ((VersionRange) yourRange).version.getPrevVersion();
+          break;
+        default:
+          useYourVersion = ((VersionRange) yourRange).version;
+          break;
+      }
+      if (this.contains(useYourVersion)) {
+        return true;
+      }
+
+      // Special case: Versions right next to each other >1.2.6 & <1.2.7
+      // There may be micro-versions or snapshot versions between them
+      if (this.version.equals(useYourVersion) && ((VersionRange) yourRange).version.equals(useMyVersion)) {
         return true;
       }
     }

--- a/src/main/java/net/ossindex/version/parser/Version.g4
+++ b/src/main/java/net/ossindex/version/parser/Version.g4
@@ -21,7 +21,7 @@ grammar Version;
         /**
          * No whitespace in the HIDDEN channel
          */
-	private boolean notWhitespace() {
+	private boolean nw() {
 	  return !whitespace();
 	}
 }
@@ -138,25 +138,26 @@ prefixed_version
  * though they may not strictly match. Close enough to handle in this one place.
  */
 postfix_version
-	: NUMBER '.' NUMBER '.' NUMBER '.' NUMBER identifier
-	| NUMBER '.' NUMBER '.' NUMBER '.' NUMBER '.' identifier
-	| NUMBER '.' NUMBER '.' NUMBER '.' NUMBER '-' identifier
-	| NUMBER '.' NUMBER '.' NUMBER identifier
-	| NUMBER '.' NUMBER '.' NUMBER '.' identifier
-	| NUMBER '.' NUMBER '.' NUMBER '-' identifier
-	| NUMBER '.' NUMBER identifier
-	| NUMBER '.' NUMBER '.' identifier
-	| NUMBER '.' NUMBER '-' identifier
+	: NUMBER dot NUMBER dot NUMBER dot NUMBER sep identifier
+	| NUMBER dot NUMBER dot NUMBER sep identifier
+	| NUMBER dot NUMBER sep identifier
 	;
 
 /** Simple numeric matching. Strip trailing dots if they exist.
  */
 numeric_version
-	: NUMBER '.' NUMBER '.' NUMBER '.' NUMBER '.'?
-	| NUMBER '.' NUMBER '.' NUMBER '.'?
-	| NUMBER '.' NUMBER '.'?
-	| NUMBER '.'?
+	: NUMBER dot NUMBER dot NUMBER dot NUMBER dot?
+	| NUMBER dot NUMBER dot NUMBER dot?
+	| NUMBER dot NUMBER dot?
+	| NUMBER dot?
 	;
+
+sep
+  : {nw()}? (
+    '.' | '_' | '-'
+  ) {nw()}?;
+
+dot : {nw()}? '.' {nw()}?;
 
 /** A fall back for when all else fails. Spaces are not valid in named versions, regardless.
  */
@@ -168,7 +169,7 @@ named_version : valid_named_version;
  */
 valid_named_version
 	: any
-	| any {notWhitespace()}? valid_named_version
+	| any {nw()}? valid_named_version
 	;
 
 /** Note that identifier is NOT GREEDY.

--- a/src/main/java/net/ossindex/version/parser/Version.g4
+++ b/src/main/java/net/ossindex/version/parser/Version.g4
@@ -4,24 +4,6 @@ grammar Version;
 }
 
 @parser::members {
-	// From: http://stackoverflow.com/questions/29060496/allow-whitespace-sections-antlr4/29115489#29115489
-	/** We can enable and disable whitespace, which is required for some special
-	 * parsing rules.
-	 */
-	 /*
-	public void enableWs() {
-	    if (_input instanceof MultiChannelTokenStream) {
-	        ((MultiChannelTokenStream) _input).enable(HIDDEN);
-	    }
-	}
-	
-	public void disableWs() {
-	    if (_input instanceof MultiChannelTokenStream) {
-	        ((MultiChannelTokenStream) _input).disable(HIDDEN);
-	    }
-	}
-	*/
-	
 	/**
 	 * Returns true if there is whitespace ahead in the HIDDEN channel.
 	 */
@@ -34,6 +16,13 @@ grammar Version;
 		
 		int type = ahead.getType();
 		return (type == WS);
+	}
+
+        /**
+         * No whitespace in the HIDDEN channel
+         */
+	private boolean notWhitespace() {
+	  return !whitespace();
 	}
 }
 
@@ -169,10 +158,17 @@ numeric_version
 	| NUMBER '.'?
 	;
 
-/** A fall back for when all else fails
+/** A fall back for when all else fails. Spaces are not valid in named versions, regardless.
  */
-named_version
-	: any+
+named_version : valid_named_version;
+
+/** Named versions can contain all sorts of crazy values. We try and avoid completely invalid named
+ * versions by disallowing certain "special characters" that should never be used in a named version
+ * unless the developer is particularly mad.
+ */
+valid_named_version
+	: any
+	| any {notWhitespace()}? valid_named_version
 	;
 
 /** Note that identifier is NOT GREEDY.

--- a/src/main/java/net/ossindex/version/parser/Version.g4
+++ b/src/main/java/net/ossindex/version/parser/Version.g4
@@ -139,8 +139,11 @@ prefixed_version
  */
 postfix_version
 	: NUMBER dot NUMBER dot NUMBER dot NUMBER sep identifier
+	| NUMBER dot NUMBER dot NUMBER dot NUMBER {nw()}? identifier
 	| NUMBER dot NUMBER dot NUMBER sep identifier
+	| NUMBER dot NUMBER dot NUMBER {nw()}? identifier
 	| NUMBER dot NUMBER sep identifier
+	| NUMBER dot NUMBER {nw()}? identifier
 	;
 
 /** Simple numeric matching. Strip trailing dots if they exist.
@@ -157,6 +160,8 @@ sep
     '.' | '_' | '-'
   ) {nw()}?;
 
+/** Do we need to loosen this up to allow spaces around dots?
+ */
 dot : {nw()}? '.' {nw()}?;
 
 /** A fall back for when all else fails. Spaces are not valid in named versions, regardless.

--- a/src/test/java/net/ossindex/version/ContainsTests.java
+++ b/src/test/java/net/ossindex/version/ContainsTests.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -19,502 +18,503 @@ public class ContainsTests
 {
 
   @Test
-  public void testLtRange()
+  public void testLtRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5");
     assertNotNull(range);
     assertEquals("<1.2.5", range.toString());
     assertEquals("(,1.2.5)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.4")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.4")));
   }
 
   @Test
-  public void testLeRange()
+  public void testLeRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<=1.2.5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<=1.2.5");
     assertNotNull(range);
     assertEquals("<=1.2.5", range.toString());
     assertEquals("(,1.2.5]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
   }
 
   @Test
-  public void testGtRange()
+  public void testGtRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">1.2.5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">1.2.5");
     assertNotNull(range);
     assertEquals(">1.2.5", range.toString());
     assertEquals("(1.2.5,)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("2.2.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("2.2.6")));
   }
 
   @Test
-  public void testGeRange()
+  public void testGeRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=1.2.5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=1.2.5");
     assertNotNull(range);
     assertEquals(">=1.2.5", range.toString());
     assertEquals("[1.2.5,)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
   }
 
   @Test
-  public void testExactVersion()
+  public void testExactVersion() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("1.2.5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("1.2.5");
     assertNotNull(range);
     assertTrue(range instanceof VersionSet);
     assertEquals("1.2.5", range.toString());
     assertEquals("[1.2.5]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
   }
 
   @Test
-  public void testVersionSet()
+  public void testVersionSet() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("1.2.5,1.2.6,1.2.8");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("1.2.5,1.2.6,1.2.8");
     assertNotNull(range);
     assertTrue(range instanceof VersionSet);
     assertEquals("1.2.5,1.2.6,1.2.8", range.toString());
     assertEquals("[1.2.5],[1.2.6],[1.2.8]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.6")));
   }
 
   @Test
-  public void testAndVersion()
+  public void testAndVersion() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">1.2.5 & <1.3");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">1.2.5 & <1.3");
     assertNotNull(range);
     assertEquals(">1.2.5 <1.3.0", range.toString());
     assertEquals("(1.2.5,1.3.0)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.6")));
   }
 
   /**
    * Using a space instead of the and
    */
   @Test
-  public void testSpaceAndVersion()
+  public void testSpaceAndVersion() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">1.2.5 <1.3");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">1.2.5 <1.3");
     assertNotNull(range);
     assertEquals(">1.2.5 <1.3.0", range.toString());
     assertEquals("(1.2.5,1.3.0)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.6")));
   }
 
   @Test
-  public void testOrVersion()
+  public void testOrVersion() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5 | >1.3");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5 | >1.3");
     assertNotNull(range);
     assertEquals("<1.2.5 | >1.3.0", range.toString());
     assertEquals("(,1.2.5),(1.3.0,)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.5")));
-    assertFalse(range.contains(VersionFactory.getVersion("1.3.0")));
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.6")));
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.4")));
-    assertTrue(range.contains(VersionFactory.getVersion("1.3.1")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.3.0")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.4")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.3.1")));
   }
 
 
   @Test
-  public void testBracketedRange()
+  public void testBracketedRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(>1.2.5 & <1.3)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(>1.2.5 & <1.3)");
     assertNotNull(range);
     assertEquals(">1.2.5 <1.3.0", range.toString());
     assertEquals("(1.2.5,1.3.0)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.6")));
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.9")));
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.99")));
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.5")));
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5.99")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.9")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.99")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.99")));
   }
 
   @Test
-  public void testComplexLogic()
+  public void testComplexLogic() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(>1.2.5 & <1.3) | (>2.2.5 & <2.3)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(>1.2.5 & <1.3) | (>2.2.5 & <2.3)");
     assertNotNull(range);
     assertEquals(">1.2.5 <1.3.0 | >2.2.5 <2.3.0", range.toString());
     assertEquals("(1.2.5,1.3.0),(2.2.5,2.3.0)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.6")));
-    assertTrue(range.contains(VersionFactory.getVersion("2.2.6")));
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.5")));
-    assertFalse(range.contains(VersionFactory.getVersion("1.3.1")));
-    assertFalse(range.contains(VersionFactory.getVersion("2.3.1")));
-    assertFalse(range.contains(VersionFactory.getVersion("2.4")));
-    assertFalse(range.contains(VersionFactory.getVersion("bob")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("2.2.6")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.3.1")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("2.3.1")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("2.4")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("bob")));
   }
 
   @Test
-  public void testInvalidRangeWithImplicitAnd()
+  public void testInvalidRangeWithImplicitAnd() throws InvalidRangeException
   {
     try {
-      IVersionRange range = VersionFactory.getRange(">=2.10 <=2.2.4");
+      IVersionRange range = VersionFactory.getVersionFactory().getRange(">=2.10 <=2.2.4");
       fail("Expected AssertionError");
     }
-    catch (AssertionError e) {
+    catch (InvalidRangeException e) {
       assertEquals(e.getMessage(), "Anded ranges do not intersect; this can never happen [>=2.10.0 & <=2.2.4]");
     }
   }
 
   @Test
-  public void testInvalidRangeWithExplicitAnd()
+  public void testInvalidRangeWithExplicitAnd() throws InvalidRangeException
   {
     try {
-      IVersionRange range = VersionFactory.getRange(">=2.10 & <=2.2.4");
+      IVersionRange range = VersionFactory.getVersionFactory().getRange(">=2.10 & <=2.2.4");
       fail("Expected AssertionError");
     }
-    catch (AssertionError e) {
+    catch (InvalidRangeException e) {
       assertEquals(e.getMessage(), "Anded ranges do not intersect; this can never happen [>=2.10.0 & <=2.2.4]");
     }
   }
 
   @Test
-  public void testComplexRangeClause()
+  public void testComplexRangeClause() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=3.1.0 <3.1.4 ");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=3.1.0 <3.1.4 ");
     assertEquals("[3.1.0,3.1.4)", range.toMavenString());
     assertNotNull(range);
-    assertTrue(range.contains(VersionFactory.getVersion("3.1.3")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("3.1.3")));
   }
 
   @Test
-  public void testComplexRangeSinglePipeWithBrackets()
+  public void testComplexRangeSinglePipeWithBrackets() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(>=3.0.0 <3.0.4) | (>=3.1.0 <3.1.4)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(>=3.0.0 <3.0.4) | (>=3.1.0 <3.1.4)");
     assertEquals("[3.0.0,3.0.4),[3.1.0,3.1.4)", range.toMavenString());
     assertNotNull(range);
-    assertTrue(range.contains(VersionFactory.getVersion("3.1.3")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("3.1.3")));
   }
 
   @Test
-  public void testComplexRangeSinglePipe()
+  public void testComplexRangeSinglePipe() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=3.0.0 <3.0.4 | >=3.1.0 <3.1.4");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=3.0.0 <3.0.4 | >=3.1.0 <3.1.4");
     assertEquals("[3.0.0,3.0.4),[3.1.0,3.1.4)", range.toMavenString());
     assertNotNull(range);
-    assertTrue(range.contains(VersionFactory.getVersion("3.1.3")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("3.1.3")));
   }
 
   @Test
-  public void testComplexRangeDoublePipe()
+  public void testComplexRangeDoublePipe() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=3.0.0 <3.0.4 || >=3.1.0 <3.1.4 ");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=3.0.0 <3.0.4 || >=3.1.0 <3.1.4 ");
     assertEquals("[3.0.0,3.0.4),[3.1.0,3.1.4)", range.toMavenString());
     assertNotNull(range);
-    assertTrue(range.contains(VersionFactory.getVersion("3.1.3")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("3.1.3")));
   }
 
 
   @Test
-  public void testComplexRange()
+  public void testComplexRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<2.8.9 || >=3.0.0 <3.0.4 || >=3.1.0 <3.1.4 ");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<2.8.9 || >=3.0.0 <3.0.4 || >=3.1.0 <3.1.4 ");
     assertNotNull(range);
     assertEquals("(,2.8.9),[3.0.0,3.0.4),[3.1.0,3.1.4)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("3.0.0")));
-    assertTrue(range.contains(VersionFactory.getVersion("3.1.0")));
-    assertTrue(range.contains(VersionFactory.getVersion("3.1.3")));
-    assertTrue(range.contains(VersionFactory.getVersion("1.1.3")));
-    assertTrue(range.contains(VersionFactory.getVersion("3.0.3")));
-    assertFalse(range.contains(VersionFactory.getVersion("3.0.4")));
-    assertFalse(range.contains(VersionFactory.getVersion("2.8.9")));
-    assertFalse(range.contains(VersionFactory.getVersion("3.1.4")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("3.0.0")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("3.1.0")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("3.1.3")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.1.3")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("3.0.3")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("3.0.4")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("2.8.9")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("3.1.4")));
   }
 
   @Test
-  public void testLtRcRange()
+  public void testLtRcRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5-rc5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5-rc5");
     assertNotNull(range);
     assertEquals("<1.2.5-rc5", range.toString());
     assertEquals("(,1.2.5-rc5)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.4")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.4")));
   }
 
 
   @Test
-  public void testRcLtRcRange()
+  public void testRcLtRcRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5-rc5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5-rc5");
     assertNotNull(range);
     assertEquals("<1.2.5-rc5", range.toString());
     assertEquals("(,1.2.5-rc5)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5-rc4")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5-rc4")));
   }
 
   @Test
-  public void testNotLtRcRange()
+  public void testNotLtRcRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5-rc5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5-rc5");
     assertNotNull(range);
     assertEquals("<1.2.5-rc5", range.toString());
     assertEquals("(,1.2.5-rc5)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.6")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.6")));
   }
 
 
   @Test
-  public void testNotRcLtRcRange()
+  public void testNotRcLtRcRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5-rc5");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5-rc5");
     assertNotNull(range);
     assertEquals("<1.2.5-rc5", range.toString());
     assertEquals("(,1.2.5-rc5)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.5-rc6")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5-rc6")));
   }
 
   @Test
-  public void testLt4digitRange1()
+  public void testLt4digitRange1() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5.6");
     assertNotNull(range);
     assertEquals("<1.2.5.6", range.toString());
     assertEquals("(,1.2.5.6)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.5")));
   }
 
   @Test
-  public void testLt4digitRange2()
+  public void testLt4digitRange2() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5.6");
     assertNotNull(range);
     assertEquals("<1.2.5.6", range.toString());
     assertEquals("(,1.2.5.6)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
   }
 
   @Test
-  public void testLt4digitRange3()
+  public void testLt4digitRange3() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5.6");
     assertNotNull(range);
     assertEquals("<1.2.5.6", range.toString());
     assertEquals("(,1.2.5.6)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.4.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.4.6")));
   }
 
   @Test
-  public void testLte4digitRange1()
+  public void testLte4digitRange1() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<=1.2.5.0");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<=1.2.5.0");
     assertNotNull(range);
     assertEquals("<=1.2.5.0", range.toString());
     assertEquals("(,1.2.5.0]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
   }
 
   @Test
-  public void testLte4digitRange2()
+  public void testLte4digitRange2() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<=1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<=1.2.5.6");
     assertNotNull(range);
     assertEquals("<=1.2.5.6", range.toString());
     assertEquals("(,1.2.5.6]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.5")));
   }
 
   @Test
-  public void testLte4digitRange3()
+  public void testLte4digitRange3() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<=1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<=1.2.5.6");
     assertNotNull(range);
     assertEquals("<=1.2.5.6", range.toString());
     assertEquals("(,1.2.5.6]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.6")));
   }
 
   @Test
-  public void testNotLt4digitRange1()
+  public void testNotLt4digitRange1() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5.6");
     assertNotNull(range);
     assertEquals("<1.2.5.6", range.toString());
     assertEquals("(,1.2.5.6)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.5.7")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.7")));
   }
 
   @Test
-  public void testNotLt4digitRange2()
+  public void testNotLt4digitRange2() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.2.5.6");
     assertNotNull(range);
     assertEquals("<1.2.5.6", range.toString());
     assertEquals("(,1.2.5.6)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.5.6")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.6")));
   }
 
   @Test
-  public void testGt4digitRange1()
+  public void testGt4digitRange1() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">1.2.5.6");
     assertNotNull(range);
     assertEquals(">1.2.5.6", range.toString());
     assertEquals("(1.2.5.6,)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5.7")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.7")));
   }
 
   @Test
-  public void testNotGt4digitRange2()
+  public void testNotGt4digitRange2() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">1.2.5.6");
     assertNotNull(range);
     assertEquals(">1.2.5.6", range.toString());
     assertEquals("(1.2.5.6,)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.5")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
   }
 
   @Test
-  public void testNotGt4digitRange3()
+  public void testNotGt4digitRange3() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">1.2.5.6");
     assertNotNull(range);
     assertEquals(">1.2.5.6", range.toString());
     assertEquals("(1.2.5.6,)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.4.6")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.4.6")));
   }
 
   @Test
-  public void testGte4digitRange1()
+  public void testGte4digitRange1() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=1.2.5.0");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=1.2.5.0");
     assertNotNull(range);
     assertEquals(">=1.2.5.0", range.toString());
     assertEquals("[1.2.5.0,)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5")));
   }
 
   @Test
-  public void testGte4digitRange2()
+  public void testGte4digitRange2() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=1.2.5.6");
     assertNotNull(range);
     assertEquals(">=1.2.5.6", range.toString());
     assertEquals("[1.2.5.6,)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5.7")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.7")));
   }
 
   @Test
-  public void testGte4digitRange3()
+  public void testGte4digitRange3() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=1.2.5.6");
     assertNotNull(range);
     assertEquals(">=1.2.5.6", range.toString());
     assertEquals("[1.2.5.6,)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5.6")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.6")));
   }
 
   @Test
-  public void testNotGt4digitRange1()
+  public void testNotGt4digitRange1() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">1.2.5.6");
     assertNotNull(range);
     assertEquals(">1.2.5.6", range.toString());
     assertEquals("(1.2.5.6,)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("1.2.5.5")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.5")));
   }
 
   @Test
-  public void testGt4digitRange2()
+  public void testGt4digitRange2() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">1.2.5.6");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">1.2.5.6");
     assertNotNull(range);
     assertEquals(">1.2.5.6", range.toString());
     assertEquals("(1.2.5.6,)", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("1.2.5.7")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("1.2.5.7")));
   }
 
   @Test
-  public void test4digitRangeWith3DigitRange()
+  public void test4digitRangeWith3DigitRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.8.0.9");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.8.0.9");
     assertNotNull(range);
     assertEquals("<1.8.0.9", range.toString());
     assertEquals("(,1.8.0.9)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("2.3.2")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("2.3.2")));
   }
 
 
   @Test
-  public void testRangeContainsRelease()
+  public void testRangeContainsRelease() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory
+    IVersionRange range = VersionFactory.getVersionFactory()
         .getRange(">=2.5.0 <=2.5.6 || 2.5.6.SEC01 || 2.5.6.SEC02 || 2.5.7 || >=3.0.0 <3.0.3");
     assertNotNull(range);
     assertEquals(">=2.5.0 <=2.5.6 | 2.5.6-SEC01 | 2.5.6-SEC02 | 2.5.7 | >=3.0.0 <3.0.3", range.toString());
     assertEquals("[2.5.0,2.5.6],[2.5.6-SEC01],[2.5.6-SEC02],[2.5.7],[3.0.0,3.0.3)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("4.3.7.RELEASE")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.7.RELEASE")));
   }
 
   @Test
-  public void testContainsWithFinalSuffix()
+  public void testContainsWithFinalSuffix() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=4.1.0 <4.2.1 || >=4.3.0 <4.3.2 || >=5.0.0 <5.1.2");
+    IVersionRange range = VersionFactory.getVersionFactory()
+        .getRange(">=4.1.0 <4.2.1 || >=4.3.0 <4.3.2 || >=5.0.0 <5.1.2");
     assertNotNull(range);
     assertEquals(">=4.1.0 <4.2.1 | >=4.3.0 <4.3.2 | >=5.0.0 <5.1.2", range.toString());
     assertEquals("[4.1.0,4.2.1),[4.3.0,4.3.2),[5.0.0,5.1.2)", range.toMavenString());
-    assertFalse(range.contains(VersionFactory.getVersion("4.3.2")));
-    assertFalse(range.contains(VersionFactory.getVersion("4.3.2.Final")));
-    assertFalse(range.contains(VersionFactory.getVersion("4.3.2.RELEASE")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.Final")));
+    assertFalse(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.RELEASE")));
   }
 
   @Test
-  public void testUnarySetContainsWithFinalSuffix()
+  public void testUnarySetContainsWithFinalSuffix() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("4.3.2");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("4.3.2");
     assertNotNull(range);
     assertEquals("4.3.2", range.toString());
     assertEquals("[4.3.2]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2")));
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2.Final")));
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2.RELEASE")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.Final")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.RELEASE")));
   }
 
   @Test
-  public void testUnaryRangeContainsWithFinalSuffix()
+  public void testUnaryRangeContainsWithFinalSuffix() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<=4.3.2");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<=4.3.2");
     assertNotNull(range);
     assertEquals("<=4.3.2", range.toString());
     assertEquals("(,4.3.2]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2")));
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2.Final")));
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2.RELEASE")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.Final")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.RELEASE")));
   }
 
   @Test
-  public void testUnaryFinalSetContainsWithFinalSuffix()
+  public void testUnaryFinalSetContainsWithFinalSuffix() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("4.3.2-Final");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("4.3.2-Final");
     assertNotNull(range);
     assertEquals("4.3.2", range.toString());
     assertEquals("[4.3.2]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2")));
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2.Final")));
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2.RELEASE")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.Final")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.RELEASE")));
   }
 
   @Test
-  public void testBinaryFinalSetContainsWithFinalSuffix()
+  public void testBinaryFinalSetContainsWithFinalSuffix() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("4.3.2-Final | 4.3.1-GA");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("4.3.2-Final | 4.3.1-GA");
     assertNotNull(range);
     assertEquals("4.3.1 | 4.3.2", range.toString());
     assertEquals("[4.3.1],[4.3.2]", range.toMavenString());
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2")));
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2.Final")));
-    assertTrue(range.contains(VersionFactory.getVersion("4.3.2.RELEASE")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.Final")));
+    assertTrue(range.contains(VersionFactory.getVersionFactory().getVersion("4.3.2.RELEASE")));
   }
 
   @Test
-  public void testOpenEndedContainsClosed()
+  public void testOpenEndedContainsClosed() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange("<1.10.10");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("<1.10.10");
     assertNotNull(range1);
-    IVersionRange range2 = VersionFactory.getRange(">=1.10.1 <1.10.10");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange(">=1.10.1 <1.10.10");
     assertTrue(range1.contains(range2));
   }
 }

--- a/src/test/java/net/ossindex/version/IntersectionTests.java
+++ b/src/test/java/net/ossindex/version/IntersectionTests.java
@@ -16,52 +16,52 @@ public class IntersectionTests
    *
    */
   @Test
-  public void testSetIntersection()
+  public void testSetIntersection() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange("1.2.5,1.2.6,1.2.8");
-    IVersionRange range2 = VersionFactory.getRange("1.2.6,1.2.9");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("1.2.5,1.2.6,1.2.8");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange("1.2.6,1.2.9");
     assertTrue(range1.intersects(range2));
   }
 
   @Test
-  public void testSetOverlappingRange()
+  public void testSetOverlappingRange() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange("<1.5");
-    IVersionRange range2 = VersionFactory.getRange("1.2.6,2.2.9");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("<1.5");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange("1.2.6,2.2.9");
     assertTrue(range1.intersects(range2));
   }
 
   @Test
-  public void testRangeOverlappingSet()
+  public void testRangeOverlappingSet() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange("1.2.2,2.2.9");
-    IVersionRange range2 = VersionFactory.getRange(">1.2");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("1.2.2,2.2.9");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange(">1.2");
     assertTrue(range1.intersects(range2));
   }
 
 
   @Test
-  public void testOverlappingSimpleRanges()
+  public void testOverlappingSimpleRanges() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange("<1.5");
-    IVersionRange range2 = VersionFactory.getRange(">1.2");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("<1.5");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange(">1.2");
     assertTrue(range1.intersects(range2));
   }
 
   @Test
-  public void testOverlappingComplexRanges()
+  public void testOverlappingComplexRanges() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange("(>0.2 & <0.5) | (>1.2 & <1.5)");
-    IVersionRange range2 = VersionFactory.getRange("(>1.4 & <1.9) | (>2.4 & <2.9)");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("(>0.2 & <0.5) | (>1.2 & <1.5)");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange("(>1.4 & <1.9) | (>2.4 & <2.9)");
     assertTrue(range1.intersects(range2));
   }
 
   @Test
-  public void testOverlappingSimpleRanges2()
+  public void testOverlappingSimpleRanges2() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange(">=4.2.5");
-    IVersionRange range2 = VersionFactory.getRange(">=4.2.5.1");
-    IVersion version2 = VersionFactory.getVersion(">=4.2.5.1");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange(">=4.2.5");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange(">=4.2.5.1");
+    IVersion version2 = VersionFactory.getVersionFactory().getVersion(">=4.2.5.1");
     assertTrue(range1.contains(version2));
     assertTrue(range1.intersects(range2));
   }

--- a/src/test/java/net/ossindex/version/InverseRangeTests.java
+++ b/src/test/java/net/ossindex/version/InverseRangeTests.java
@@ -15,8 +15,8 @@ public class InverseRangeTests
 {
 
   @Test
-  public void simpleVersionRangeInversionTest() {
-    IVersionRange range = VersionFactory.getRange(">= 1.9.3");
+  public void simpleVersionRangeInversionTest() throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">= 1.9.3");
     assertNotNull(range);
     assertEquals(">=1.9.3", range.toString());
 
@@ -25,7 +25,7 @@ public class InverseRangeTests
     assertEquals("<1.9.3", irange.toString());
 
 
-    range = VersionFactory.getRange("> 1.9.3");
+    range = VersionFactory.getVersionFactory().getRange("> 1.9.3");
     assertNotNull(range);
     assertEquals(">1.9.3", range.toString());
 
@@ -34,7 +34,7 @@ public class InverseRangeTests
     assertEquals("<=1.9.3", irange.toString());
 
 
-    range = VersionFactory.getRange("<= 1.9.3");
+    range = VersionFactory.getVersionFactory().getRange("<= 1.9.3");
     assertNotNull(range);
     assertEquals("<=1.9.3", range.toString());
 
@@ -43,7 +43,7 @@ public class InverseRangeTests
     assertEquals(">1.9.3", irange.toString());
 
 
-    range = VersionFactory.getRange("< 1.9.3");
+    range = VersionFactory.getVersionFactory().getRange("< 1.9.3");
     assertNotNull(range);
     assertEquals("<1.9.3", range.toString());
 
@@ -53,8 +53,8 @@ public class InverseRangeTests
   }
 
   @Test
-  public void andRangeInversionTest() {
-    IVersionRange range = VersionFactory.getRange("~> 1.9.3.484");
+  public void andRangeInversionTest() throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("~> 1.9.3.484");
     assertNotNull(range);
     assertEquals(">=1.9.3.484 <1.9.4.0", range.toString());
 
@@ -64,16 +64,16 @@ public class InverseRangeTests
   }
 
   @Test
-  public void andRangeOverlapTest() {
-    IVersionRange range = VersionFactory.getRange("~> 4.2.5, >= 4.2.5.1");
+  public void andRangeOverlapTest() throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("~> 4.2.5, >= 4.2.5.1");
     assertNotNull(range);
     assertEquals(">=4.2.5.1 <4.3.0", range.toString());
   }
 
 
   @Test
-  public void orRangeInversionTest() {
-    IVersionRange range = VersionFactory.getRange("<1.0.0 | >2.0.0");
+  public void orRangeInversionTest() throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.0.0 | >2.0.0");
     assertNotNull(range);
     assertEquals("<1.0.0 | >2.0.0", range.toString());
 
@@ -83,36 +83,36 @@ public class InverseRangeTests
   }
 
   @Test
-  public void mergeOredRanges() {
-    IVersionRange range1 = VersionFactory.getRange(">1.0.0");
-    IVersionRange range2 = VersionFactory.getRange("<2.0.0 | >3.0.0");
-    IVersionRange range3 = VersionFactory.getRange("<4.0.0 | >5.0.0");
-    IVersionRange range4 = VersionFactory.getRange("<6.0.0");
+  public void mergeOredRanges() throws InvalidRangeException {
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange(">1.0.0");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange("<2.0.0 | >3.0.0");
+    IVersionRange range3 = VersionFactory.getVersionFactory().getRange("<4.0.0 | >5.0.0");
+    IVersionRange range4 = VersionFactory.getVersionFactory().getRange("<6.0.0");
 
-    IVersionRange arange = VersionFactory.merge(range1, range2);
+    IVersionRange arange = VersionFactory.getVersionFactory().merge(range1, range2);
     assertEquals(">1.0.0 <2.0.0 | >3.0.0", arange.toString());
 
-    arange = VersionFactory.merge(range2, range3);
+    arange = VersionFactory.getVersionFactory().merge(range2, range3);
     assertEquals("<2.0.0 | >3.0.0 <4.0.0 | >5.0.0", arange.toString());
 
-    arange = VersionFactory.merge(range3, range4);
+    arange = VersionFactory.getVersionFactory().merge(range3, range4);
     assertEquals("<4.0.0 | >5.0.0 <6.0.0", arange.toString());
 
-    arange = VersionFactory.merge(range1, range2, range3, range4);
+    arange = VersionFactory.getVersionFactory().merge(range1, range2, range3, range4);
     assertEquals(">1.0.0 <2.0.0 | >3.0.0 <4.0.0 | >5.0.0 <6.0.0", arange.toString());
   }
 
   @Test
-  public void complexInversion() {
-    IVersionRange range1 = VersionFactory.getRange("~> 1.9.3.484");
-    IVersionRange range2 = VersionFactory.getRange("~> 2.0.0.353");
-    IVersionRange range3 = VersionFactory.getRange(">= 2.1.0.preview.2");
+  public void complexInversion() throws InvalidRangeException {
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("~> 1.9.3.484");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange("~> 2.0.0.353");
+    IVersionRange range3 = VersionFactory.getVersionFactory().getRange(">= 2.1.0.preview.2");
 
     IVersionRange irange1 = range1.invert();
     IVersionRange irange2 = range2.invert();
     IVersionRange irange3 = range3.invert();
 
-    IVersionRange merge = VersionFactory.merge(irange1, irange2, irange3);
+    IVersionRange merge = VersionFactory.getVersionFactory().merge(irange1, irange2, irange3);
     assertEquals("<1.9.3.484 | >=1.9.4.0 <2.0.0.353 | >=2.0.1.0 <2.1.0-preview.2", merge.toString());
   }
 
@@ -121,12 +121,12 @@ public class InverseRangeTests
    */
   @Test
   @Ignore
-  public void betaInversion() {
-    IVersionRange range1 = VersionFactory.getRange("~> 4.1.7");
-    IVersionRange range2 = VersionFactory.getRange(">=4.2.0-beta3");
+  public void betaInversion() throws InvalidRangeException {
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("~> 4.1.7");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange(">=4.2.0-beta3");
     IVersionRange irange1 = range1.invert();
     IVersionRange irange2 = range2.invert();
-    IVersionRange merge = VersionFactory.merge(irange1, irange2);
+    IVersionRange merge = VersionFactory.getVersionFactory().merge(irange1, irange2);
     assertEquals("<4.1.7 | >4.1.99999999 <4.2.0-beta3", merge.toString());
   }
 }

--- a/src/test/java/net/ossindex/version/MavenRangeTests.java
+++ b/src/test/java/net/ossindex/version/MavenRangeTests.java
@@ -14,151 +14,151 @@ public class MavenRangeTests
 {
 
   @Test
-  public void inclusiveVersionTest()
+  public void inclusiveVersionTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("4.3.2");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("4.3.2");
     assertNotNull(range);
     assertEquals("4.3.2", range.toString());
   }
 
   @Test
-  public void inclusiveVersionSetTest()
+  public void inclusiveVersionSetTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[4.3.2]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[4.3.2]");
     assertNotNull(range);
     assertEquals("4.3.2", range.toString());
   }
 
   @Test
-  public void inclusiveRangeUpperBoundTest()
+  public void inclusiveRangeUpperBoundTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[,4.3.2]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[,4.3.2]");
     assertNotNull(range);
     assertEquals("<=4.3.2", range.toString());
   }
 
   @Test
-  public void inclusiveRangeLowerBoundTest()
+  public void inclusiveRangeLowerBoundTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[4.3.2,]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[4.3.2,]");
     assertNotNull(range);
     assertEquals(">=4.3.2", range.toString());
   }
 
   @Test
-  public void inclusiveRangeUpperBound2Test()
+  public void inclusiveRangeUpperBound2Test() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(,4.3.2]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(,4.3.2]");
     assertNotNull(range);
     assertEquals("<=4.3.2", range.toString());
   }
 
   @Test
-  public void inclusiveRangeLowerBound2Test()
+  public void inclusiveRangeLowerBound2Test() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[4.3.2,)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[4.3.2,)");
     assertNotNull(range);
     assertEquals(">=4.3.2", range.toString());
   }
 
   @Test
-  public void exclusiveRangeUpperBoundTest()
+  public void exclusiveRangeUpperBoundTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(,4.3.2)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(,4.3.2)");
     assertNotNull(range);
     assertEquals("<4.3.2", range.toString());
   }
 
   @Test
-  public void exclusiveRangeLowerBoundTest()
+  public void exclusiveRangeLowerBoundTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(4.3.2,)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(4.3.2,)");
     assertNotNull(range);
     assertEquals(">4.3.2", range.toString());
   }
 
   @Test
-  public void exclusiveRangeUpperBound2Test()
+  public void exclusiveRangeUpperBound2Test() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[,4.3.2)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[,4.3.2)");
     assertNotNull(range);
     assertEquals("<4.3.2", range.toString());
   }
 
   @Test
-  public void exclusiveRangeLowerBound2Test()
+  public void exclusiveRangeLowerBound2Test() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(4.3.2,]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(4.3.2,]");
     assertNotNull(range);
     assertEquals(">4.3.2", range.toString());
   }
 
   @Test
-  public void exclusiveRangeTest()
+  public void exclusiveRangeTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(1.0,2.0)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(1.0,2.0)");
     assertNotNull(range);
     assertEquals(">1.0.0 <2.0.0", range.toString());
   }
 
   @Test
-  public void inclusiveRangeTest()
+  public void inclusiveRangeTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[1.0,2.0]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[1.0,2.0]");
     assertNotNull(range);
     assertEquals(">=1.0.0 <=2.0.0", range.toString());
   }
 
   @Test
-  public void inclusiveExclusiveRangeTest()
+  public void inclusiveExclusiveRangeTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[1.0,2.0)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[1.0,2.0)");
     assertNotNull(range);
     assertEquals(">=1.0.0 <2.0.0", range.toString());
   }
 
   @Test
-  public void exclusiveInclusiveRangeTest()
+  public void exclusiveInclusiveRangeTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(1.0,2.0]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(1.0,2.0]");
     assertNotNull(range);
     assertEquals(">1.0.0 <=2.0.0", range.toString());
   }
 
   @Test
-  public void mavenRangeUnion1Test()
+  public void mavenRangeUnion1Test() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("(1.0,2.0],[3.0,4.0)");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(1.0,2.0],[3.0,4.0)");
     assertNotNull(range);
     assertEquals(">1.0.0 <=2.0.0 | >=3.0.0 <4.0.0", range.toString());
   }
 
   @Test
-  public void mavenPostfixRangeUnionTest()
+  public void mavenPostfixRangeUnionTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[3.2,3.2.8.RELEASE], [4.0,4.0.4.RELEASE]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[3.2,3.2.8.RELEASE], [4.0,4.0.4.RELEASE]");
     assertNotNull(range);
     assertEquals(">=3.2.0 <=3.2.8 | >=4.0.0 <=4.0.4", range.toString());
   }
 
   @Test
-  public void mavenRcTest()
+  public void mavenRcTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[2.4-beta,2.4.0-rc1]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[2.4-beta,2.4.0-rc1]");
     assertNotNull(range);
     assertEquals(">=2.4.0-beta <=2.4.0-rc1", range.toString());
-    range = VersionFactory.getRange("[2.4beta,2.4.0rc1]");
+    range = VersionFactory.getVersionFactory().getRange("[2.4beta,2.4.0rc1]");
     assertNotNull(range);
     assertEquals(">=2.4.0-beta <=2.4.0-rc1", range.toString());
   }
 
   @Test
-  public void emptyRangeTest()
+  public void emptyRangeTest() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("[]");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("[]");
     assertNotNull(range);
     assertEquals("", range.toString());
-    range = VersionFactory.getRange("[-]");
+    range = VersionFactory.getVersionFactory().getRange("[-]");
     assertNotNull(range);
     assertEquals("", range.toString());
   }

--- a/src/test/java/net/ossindex/version/MavenRangeTests.java
+++ b/src/test/java/net/ossindex/version/MavenRangeTests.java
@@ -1,8 +1,12 @@
 package net.ossindex.version;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -10,23 +14,40 @@ import static org.junit.Assert.assertNotNull;
  *
  * @author Ken Duck
  */
+@RunWith(JUnitParamsRunner.class)
 public class MavenRangeTests
 {
 
   @Test
-  public void inclusiveVersionTest() throws InvalidRangeException
+  @Parameters({
+      "4.3.2.1, 4.3.2.1",
+      "4.3.2, 4.3.2",
+      "[4.3.2], 4.3.2",
+      "[4.3], 4.3.0",
+      "[4], 4.0.0",
+      "[4.3.2.1-beta], 4.3.2.1-beta",
+      "[4.3.2-beta], 4.3.2-beta",
+      "[4.3-beta], 4.3.0-beta",
+      //"[4-beta], 4.0.0-beta",
+      "[4.3.2.1_beta], 4.3.2.1-beta",
+      "[4.3.2_beta], 4.3.2-beta",
+      "[4.3_beta], 4.3.0-beta",
+      //"[4_beta], 4.0.0-beta",
+      "[4.3.2.1.beta], 4.3.2.1-beta",
+      "[4.3.2.beta], 4.3.2-beta",
+      "[4.3.beta], 4.3.0-beta",
+      //"[4.beta], 4.0.0-beta",
+      "[4.3.2.1beta], 4.3.2.1-beta",
+      "[4.3.2beta], 4.3.2-beta",
+      "[4.3beta], 4.3.0-beta",
+      //"[4beta], 4.0.0-beta",
+      "[2.4.0rc1], 2.4.0-rc1"
+  })
+  public void inclusiveVersionTest(final String rstring, final String expected) throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getVersionFactory().getRange("4.3.2");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(rstring);
     assertNotNull(range);
-    assertEquals("4.3.2", range.toString());
-  }
-
-  @Test
-  public void inclusiveVersionSetTest() throws InvalidRangeException
-  {
-    IVersionRange range = VersionFactory.getVersionFactory().getRange("[4.3.2]");
-    assertNotNull(range);
-    assertEquals("4.3.2", range.toString());
+    assertEquals(expected, range.toString());
   }
 
   @Test
@@ -161,5 +182,20 @@ public class MavenRangeTests
     range = VersionFactory.getVersionFactory().getRange("[-]");
     assertNotNull(range);
     assertEquals("", range.toString());
+  }
+
+  /**
+   * These are invalid ranges
+   */
+  @Test
+  public void invalidRangeTest() {
+    try {
+      String name = "(1.2.19,1.2.19]";
+      IVersionRange range = VersionFactory.getVersionFactory().getRange(name);
+      assertFalse("Range should be considered invalid: " + name, true);
+    }
+    catch (InvalidRangeException e) {
+      e.printStackTrace();
+    }
   }
 }

--- a/src/test/java/net/ossindex/version/RangeCompareTests.java
+++ b/src/test/java/net/ossindex/version/RangeCompareTests.java
@@ -13,63 +13,63 @@ import static org.junit.Assert.assertTrue;
 public class RangeCompareTests
 {
   @Test
-  public void versionCompareTests()
+  public void versionCompareTests() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange("1.2.5");
-    IVersionRange range2 = VersionFactory.getRange("1.2.6");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange("1.2.5");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange("1.2.6");
     assertTrue(range1.compareTo(range2) < 0);
 
-    range2 = VersionFactory.getRange("1.2.5");
+    range2 = VersionFactory.getVersionFactory().getRange("1.2.5");
     assertTrue(range1.compareTo(range2) == 0);
 
-    range2 = VersionFactory.getRange("1.2.4");
+    range2 = VersionFactory.getVersionFactory().getRange("1.2.4");
     assertTrue(range1.compareTo(range2) > 0);
   }
 
   @Test
-  public void simpleRangeCompareTests()
+  public void simpleRangeCompareTests() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange(">1.2.5");
-    IVersionRange range2 = VersionFactory.getRange(">1.2.6");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange(">1.2.5");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange(">1.2.6");
     assertTrue(range1.compareTo(range2) < 0);
 
-    range2 = VersionFactory.getRange(">1.2.5");
+    range2 = VersionFactory.getVersionFactory().getRange(">1.2.5");
     assertTrue(range1.compareTo(range2) == 0);
 
-    range2 = VersionFactory.getRange(">1.2.4");
+    range2 = VersionFactory.getVersionFactory().getRange(">1.2.4");
     assertTrue(range1.compareTo(range2) > 0);
   }
 
   @Ignore
   @Test
-  public void boundedRangeCompareTests()
+  public void boundedRangeCompareTests() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange(">1.2.5 <1.2.7");
-    IVersionRange range2 = VersionFactory.getRange(">1.2.6 <1.2.7");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange(">1.2.5 <1.2.7");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange(">1.2.6 <1.2.7");
     assertTrue(range1.compareTo(range2) < 0);
 
-    range2 = VersionFactory.getRange(">1.2.5 <1.2.7");
+    range2 = VersionFactory.getVersionFactory().getRange(">1.2.5 <1.2.7");
     assertTrue(range1.compareTo(range2) == 0);
 
-    range2 = VersionFactory.getRange(">1.2.4 <1.2.7");
+    range2 = VersionFactory.getVersionFactory().getRange(">1.2.4 <1.2.7");
     assertTrue(range1.compareTo(range2) > 0);
 
     // Bottom of range is same, but top is different
-    range2 = VersionFactory.getRange(">1.2.5 <1.2.6");
+    range2 = VersionFactory.getVersionFactory().getRange(">1.2.5 <1.2.6");
     assertTrue(range1.compareTo(range2) > 0);
   }
 
   @Test
-  public void unionRangeCompareTests()
+  public void unionRangeCompareTests() throws InvalidRangeException
   {
-    IVersionRange range1 = VersionFactory.getRange(">1.2.5 <1.2.7 | >2.2.5 <2.2.7");
-    IVersionRange range2 = VersionFactory.getRange(">1.2.6 <1.2.7 | >2.2.5 <2.2.7");
+    IVersionRange range1 = VersionFactory.getVersionFactory().getRange(">1.2.5 <1.2.7 | >2.2.5 <2.2.7");
+    IVersionRange range2 = VersionFactory.getVersionFactory().getRange(">1.2.6 <1.2.7 | >2.2.5 <2.2.7");
     assertTrue(range1.compareTo(range2) < 0);
 
-    range2 = VersionFactory.getRange(">1.2.5 <1.2.7 | >2.2.5 <2.2.7");
+    range2 = VersionFactory.getVersionFactory().getRange(">1.2.5 <1.2.7 | >2.2.5 <2.2.7");
     assertTrue(range1.compareTo(range2) == 0);
 
-    range2 = VersionFactory.getRange(">1.2.4 <1.2.7 | >2.2.5 <2.2.7");
+    range2 = VersionFactory.getVersionFactory().getRange(">1.2.4 <1.2.7 | >2.2.5 <2.2.7");
     assertTrue(range1.compareTo(range2) > 0);
   }
 }

--- a/src/test/java/net/ossindex/version/RubyRangeTests.java
+++ b/src/test/java/net/ossindex/version/RubyRangeTests.java
@@ -14,16 +14,16 @@ public class RubyRangeTests
 {
 
   @Test
-  public void simplePessimistic() {
-    IVersionRange range = VersionFactory.getRange("~> 1.9.3.484");
+  public void simplePessimistic()  throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("~> 1.9.3.484");
     assertNotNull(range);
     assertEquals(">=1.9.3.484 <1.9.4.0", range.toString());
 
-    range = VersionFactory.getRange("~> 1.9.3");
+    range = VersionFactory.getVersionFactory().getRange("~> 1.9.3");
     assertNotNull(range);
     assertEquals(">=1.9.3 <1.10.0", range.toString());
 
-    range = VersionFactory.getRange("~> 1.9");
+    range = VersionFactory.getVersionFactory().getRange("~> 1.9");
     assertNotNull(range);
     assertEquals(">=1.9.0 <2.0.0", range.toString());
   }

--- a/src/test/java/net/ossindex/version/VersionRangeTest.java
+++ b/src/test/java/net/ossindex/version/VersionRangeTest.java
@@ -203,7 +203,8 @@ public class VersionRangeTest
       "1.2.3[zounds]",
       "named version",
       "named[wow]",
-      "named(zounds)"
+      "named(zounds)",
+      "named version"
   })
   public void testStrictInvalidVersions(final String name) throws IOException
   {
@@ -216,10 +217,10 @@ public class VersionRangeTest
   }
 
   @Test
-  public void testStrictInvalidVersionWithSpace() throws IOException
+  public void testStrictCrazyInvalidVersion() throws IOException
   {
     try {
-      IVersionRange version = VersionFactory.getStrictVersionFactory().getRange("named version");
+      IVersionRange version = VersionFactory.getStrictVersionFactory().getRange(">=3.0.0 <=3.9.1 =3.10.2");
       assertFalse("Strict mode expects an exception, got " + version, true);
     }
     catch (InvalidRangeException e) {

--- a/src/test/java/net/ossindex/version/VersionRangeTest.java
+++ b/src/test/java/net/ossindex/version/VersionRangeTest.java
@@ -194,6 +194,8 @@ public class VersionRangeTest
   @Test
   @Parameters({
       ">=1.2.3 <1.1.1", // Ranges do not intersect
+      ">1.2.19 <=1.2.19]",
+      ">=1.2.19 <1.2.19]",
       "[named]",
       "(named]",
       "named&version",
@@ -210,6 +212,17 @@ public class VersionRangeTest
   {
     try {
       IVersionRange version = VersionFactory.getStrictVersionFactory().getRange(name);
+      assertFalse("Strict mode expects an exception, got " + version, true);
+    }
+    catch (InvalidRangeException e) {
+    }
+  }
+
+  @Test
+  public void testStrictInvalidVersion() throws IOException
+  {
+    try {
+      IVersionRange version = VersionFactory.getStrictVersionFactory().getRange(">1.2.19 <=1.2.19]");
       assertFalse("Strict mode expects an exception, got " + version, true);
     }
     catch (InvalidRangeException e) {

--- a/src/test/java/net/ossindex/version/VersionRangeTest.java
+++ b/src/test/java/net/ossindex/version/VersionRangeTest.java
@@ -1,14 +1,23 @@
 package net.ossindex.version;
 
+import java.io.IOException;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import net.ossindex.version.impl.NamedVersion;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Ken Duck
  */
+@RunWith(JUnitParamsRunner.class)
 public class VersionRangeTest
 {
   @Test
@@ -182,5 +191,56 @@ public class VersionRangeTest
     assertEquals("[2.0.0,2.5.3-SP13],[2.6.0,2.6.1],[2.7.0,2.7.1-Beta2]", range.toMavenString());
   }
 
+  @Test
+  @Parameters({
+      ">=1.2.3 <1.1.1", // Ranges do not intersect
+      "[named]",
+      "(named]",
+      "named&version",
+      "named=version",
+      "named>version",
+      "named<version",
+      "1.2.3[zounds]",
+      "named version",
+      "named[wow]",
+      "named(zounds)"
+  })
+  public void testStrictInvalidVersions(final String name) throws IOException
+  {
+    try {
+      IVersionRange version = VersionFactory.getStrictVersionFactory().getRange(name);
+      assertFalse("Strict mode expects an exception, got " + version, true);
+    }
+    catch (InvalidRangeException e) {
+    }
+  }
 
+  @Test
+  public void testStrictInvalidVersionWithSpace() throws IOException
+  {
+    try {
+      IVersionRange version = VersionFactory.getStrictVersionFactory().getRange("named version");
+      assertFalse("Strict mode expects an exception, got " + version, true);
+    }
+    catch (InvalidRangeException e) {
+    }
+  }
+
+  @Test
+  @Parameters({
+      "namedVersion",
+      "named-version",
+      "named.version",
+      "named+version",
+  })
+  public void testStrictValidNamedVersions(final String name) throws IOException
+  {
+    try {
+      IVersion range = VersionFactory.getStrictVersionFactory().getVersion(name);
+      assertTrue(range instanceof NamedVersion);
+    }
+    catch (InvalidRangeException e) {
+      assertFalse("Strict mode does not expect an exception", true);
+    }
+  }
 }

--- a/src/test/java/net/ossindex/version/VersionRangeTest.java
+++ b/src/test/java/net/ossindex/version/VersionRangeTest.java
@@ -12,58 +12,58 @@ import static org.junit.Assert.assertNotNull;
 public class VersionRangeTest
 {
   @Test
-  public void testComplexRange()
+  public void testComplexRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory
+    IVersionRange range = VersionFactory.getVersionFactory()
         .getRange(">=2.5.0 <=2.5.6 || 2.5.6.SEC01 || 2.5.6.SEC02 || 2.5.7 || >=3.0.0 <3.0.3");
     assertNotNull(range);
     assertEquals(">=2.5.0 <=2.5.6 | 2.5.6-SEC01 | 2.5.6-SEC02 | 2.5.7 | >=3.0.0 <3.0.3", range.toString());
   }
 
   @Test
-  public void testUnarySetRangeWithTextSuffix()
+  public void testUnarySetRangeWithTextSuffix() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("2.5.6.SEC01");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("2.5.6.SEC01");
     assertNotNull(range);
     assertEquals("2.5.6-SEC01", range.toString());
   }
 
   @Test
-  public void testBinarySimpleRanges()
+  public void testBinarySimpleRanges() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">2.5.6 || >2.5.7");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">2.5.6 || >2.5.7");
     assertNotNull(range);
     assertEquals(">2.5.6 | >2.5.7", range.toString());
   }
 
   @Test
-  public void testBinarySetRange()
+  public void testBinarySetRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("2.5.6 || 2.5.7");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("2.5.6 || 2.5.7");
     assertNotNull(range);
     assertEquals("2.5.6 | 2.5.7", range.toString());
   }
 
   @Test
-  public void testBinarySetRangeWithTextSuffix()
+  public void testBinarySetRangeWithTextSuffix() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("2.5.6.SEC01 || 2.5.6.SEC02");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("2.5.6.SEC01 || 2.5.6.SEC02");
     assertNotNull(range);
     assertEquals("2.5.6-SEC01 | 2.5.6-SEC02", range.toString());
   }
 
   @Test
-  public void testWhitespaceAndRange()
+  public void testWhitespaceAndRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("<1.4.1 >=0.4.3");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("<1.4.1 >=0.4.3");
     assertNotNull(range);
     assertEquals(">=0.4.3 <1.4.1", range.toString());
   }
 
   @Test
-  public void testCommaAndRange()
+  public void testCommaAndRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange(">=0.10.0, <0.10.2");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=0.10.0, <0.10.2");
     assertNotNull(range);
     assertEquals(">=0.10.0 <0.10.2", range.toString());
   }
@@ -73,33 +73,33 @@ public class VersionRangeTest
    */
   @Test
   @Ignore
-  public void testTildeRange()
+  public void testTildeRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("~1.2.3");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("~1.2.3");
     assertNotNull(range);
     assertEquals(">=1.2.3 <1.3.0", range.toString());
 
-    range = VersionFactory.getRange("~1.2");
+    range = VersionFactory.getVersionFactory().getRange("~1.2");
     assertNotNull(range);
     assertEquals(">=1.2.0 <1.3.0", range.toString());
 
-    range = VersionFactory.getRange("~1");
+    range = VersionFactory.getVersionFactory().getRange("~1");
     assertNotNull(range);
     assertEquals(">=1.0.0 <2.0.0", range.toString());
 
-    range = VersionFactory.getRange("~0.2.3");
+    range = VersionFactory.getVersionFactory().getRange("~0.2.3");
     assertNotNull(range);
     assertEquals(">=0.2.3 <0.3.0", range.toString());
 
-    range = VersionFactory.getRange("~0.2");
+    range = VersionFactory.getVersionFactory().getRange("~0.2");
     assertNotNull(range);
     assertEquals(">=0.2.0 <0.3.0", range.toString());
 
-    range = VersionFactory.getRange("~0");
+    range = VersionFactory.getVersionFactory().getRange("~0");
     assertNotNull(range);
     assertEquals(">=0.0.0 <1.0.0", range.toString());
 
-    range = VersionFactory.getRange("~1.2.3-beta.2");
+    range = VersionFactory.getVersionFactory().getRange("~1.2.3-beta.2");
     assertNotNull(range);
     assertEquals(">=~1.2.3-beta.2 <1.3.0", range.toString());
   }
@@ -109,25 +109,25 @@ public class VersionRangeTest
    */
   @Test
   @Ignore
-  public void testCaretRange()
+  public void testCaretRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("^1.2.3");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("^1.2.3");
     assertNotNull(range);
     assertEquals(">=1.2.3 <2.0.0", range.toString());
 
-    range = VersionFactory.getRange("^0.2.3");
+    range = VersionFactory.getVersionFactory().getRange("^0.2.3");
     assertNotNull(range);
     assertEquals(">=0.2.3 <0.3.0", range.toString());
 
-    range = VersionFactory.getRange("^0.0.3");
+    range = VersionFactory.getVersionFactory().getRange("^0.0.3");
     assertNotNull(range);
     assertEquals(">=0.0.3 <0.0.4", range.toString());
 
-    range = VersionFactory.getRange("^1.2.3-beta.2");
+    range = VersionFactory.getVersionFactory().getRange("^1.2.3-beta.2");
     assertNotNull(range);
     assertEquals(">=1.2.3-beta.2 <2.0.0", range.toString());
 
-    range = VersionFactory.getRange("^0.0.3-beta");
+    range = VersionFactory.getVersionFactory().getRange("^0.0.3-beta");
     assertNotNull(range);
     assertEquals(">=0.0.3-beta <0.0.4", range.toString());
   }
@@ -137,45 +137,47 @@ public class VersionRangeTest
    */
   @Test
   @Ignore
-  public void testXRange()
+  public void testXRange() throws InvalidRangeException
   {
-    IVersionRange range = VersionFactory.getRange("*");
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("*");
     assertNotNull(range);
     assertEquals(">=0.0.0", range.toString());
 
-    range = VersionFactory.getRange("1.x");
+    range = VersionFactory.getVersionFactory().getRange("1.x");
     assertNotNull(range);
     assertEquals(">=1.0.0 <2.0.0", range.toString());
 
-    range = VersionFactory.getRange("1.2.x");
+    range = VersionFactory.getVersionFactory().getRange("1.2.x");
     assertNotNull(range);
     assertEquals(">=1.2.0 <1.3.0", range.toString());
   }
 
   @Test
-  public void testImplicitAnd() {
-    IVersionRange range = VersionFactory.getRange(">=2.0.0 <=2.5.3-SP13");
+  public void testImplicitAnd() throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory().getRange(">=2.0.0 <=2.5.3-SP13");
     assertNotNull(range);
     assertEquals("[2.0.0,2.5.3-SP13]", range.toMavenString());
   }
 
   @Test
-  public void testUnionRanges() {
-    IVersionRange range = VersionFactory.getRange("(>=2.0.0 <=2.5.3-SP13) | (>=2.6.0 <=2.6.1)");
+  public void testUnionRanges() throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory().getRange("(>=2.0.0 <=2.5.3-SP13) | (>=2.6.0 <=2.6.1)");
     assertNotNull(range);
     assertEquals("[2.0.0,2.5.3-SP13],[2.6.0,2.6.1]", range.toMavenString());
   }
 
   @Test
-  public void testTripleUnionRanges() {
-    IVersionRange range = VersionFactory.getRange("(>=2.0.0 <=2.5.3-SP13) | (>=2.6.0 <=2.6.1) | (>=2.7.0 <=2.7.1-Beta2)");
+  public void testTripleUnionRanges() throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory()
+        .getRange("(>=2.0.0 <=2.5.3-SP13) | (>=2.6.0 <=2.6.1) | (>=2.7.0 <=2.7.1-Beta2)");
     assertNotNull(range);
     assertEquals("[2.0.0,2.5.3-SP13],[2.6.0,2.6.1],[2.7.0,2.7.1-Beta2]", range.toMavenString());
   }
 
   @Test
-  public void testNestedUnionRanges() {
-    IVersionRange range = VersionFactory.getRange("(>=2.0.0 <=2.5.3-SP13) | ((>=2.6.0 <=2.6.1) | (>=2.7.0 <=2.7.1-Beta2))");
+  public void testNestedUnionRanges() throws InvalidRangeException {
+    IVersionRange range = VersionFactory.getVersionFactory()
+        .getRange("(>=2.0.0 <=2.5.3-SP13) | ((>=2.6.0 <=2.6.1) | (>=2.7.0 <=2.7.1-Beta2))");
     assertNotNull(range);
     assertEquals("[2.0.0,2.5.3-SP13],[2.6.0,2.6.1],[2.7.0,2.7.1-Beta2]", range.toMavenString());
   }

--- a/src/test/java/net/ossindex/version/VersionTests.java
+++ b/src/test/java/net/ossindex/version/VersionTests.java
@@ -38,12 +38,16 @@ import net.ossindex.version.parser.VersionParser.RangeContext;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 /** Test the version parser
@@ -51,6 +55,7 @@ import static org.junit.Assert.assertNotNull;
  * @author Ken Duck
  *
  */
+@RunWith(JUnitParamsRunner.class)
 public class VersionTests
 {
   @Before
@@ -233,11 +238,12 @@ public class VersionTests
   }
 
   @Test
-  public void testInvalidVersion() throws IOException
+  @Parameters({"1.2.3 &, 1.2.3"})
+  public void testInvalidVersions(final String name, final String expected) throws IOException
   {
-    IVersionRange range = parseVersion("1.2.3 &");
+    IVersionRange range = parseVersion(name);
     assertNotNull(range);
-    assertEquals("1.2.3", range.toString());
+    assertEquals(expected, range.toString());
   }
 
   @Test


### PR DESCRIPTION
Story: https://issues.sonatype.org/browse/DRD-1887

Adding better exception handling and a strict mode which will allow us to prevent invalid version ranges from finding their way downstream in the feeds.